### PR TITLE
German.nsh - Just one word changed

### DIFF
--- a/Contrib/UltraModernUI/Language files/German.nsh
+++ b/Contrib/UltraModernUI/Language files/German.nsh
@@ -163,7 +163,7 @@
   ${LangFileString} UMUI_TEXT_MAINTENANCE_REPAIR_TITLE "Reparieren"
   ${LangFileString} UMUI_TEXT_MAINTENANCE_REPAIR_TEXT "Reinstallation aller bereits installierten $(^NameDA) Komponenten."
   ${LangFileString} UMUI_TEXT_MAINTENANCE_REMOVE_TITLE "Entfernen"
-  ${LangFileString} UMUI_TEXT_MAINTENANCE_REMOVE_TEXT "Deinstallation der $(^NameDA) vom Computer."
+  ${LangFileString} UMUI_TEXT_MAINTENANCE_REMOVE_TEXT "Deinstallation von $(^NameDA) vom Computer."
   ${LangFileString} UMUI_TEXT_MAINTENANCE_CONTINUE_TITLE "Installation fortsetzen"
   ${LangFileString} UMUI_TEXT_MAINTENANCE_CONTINUE_TEXT "Installation wie üblich fortsetzen. Verwenden Sie diese Option, wenn die Neuinstallation eine bereits existierende Installation überschreiben soll oder um eine Neuinstallation in einem anderen Verzeichnis durchzuführen."
 !endif


### PR DESCRIPTION
I changed just one word, but with it the string should fit to more software.
"der" (Softwarename) -> "von" (Softwarename)

![2019-04-17 02_57_10-Installation von BleachBit](https://user-images.githubusercontent.com/11881073/56371626-b9014880-61fd-11e9-8c7a-b7289c72b2dd.jpg)